### PR TITLE
feat(README.md, objects_register.py, tests): add function registratio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ class CustomHead(nn.Module):
         super(CustomHead, self).__init__()
     ...
 
+# You can do the same stuff with functions :)
+# Registered function is stored in the register as a wrapped object,
+# but can be called the normal way.
+@register_as('functions')
+def some_interesting_function(a, b, c):
+    return a * b * c
+
+assert register.functions['some_interesting_function'](1, 2, 3) == 6 # True
+
 # Update the register with the current namespace
 register.update_register()
 # register.classifier_head -> dict of all the classes in the namespace

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,13 +35,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
 ]
 
 [[package]]
@@ -61,23 +61,23 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pytest"
-version = "8.0.2"
+version = "8.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.0.2-py3-none-any.whl", hash = "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"},
-    {file = "pytest-8.0.2.tar.gz", hash = "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd"},
+    {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
+    {file = "pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=1.3.0,<2.0"
+pluggy = ">=1.4,<2.0"
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pyyaml"

--- a/tests/test_objects_register.py
+++ b/tests/test_objects_register.py
@@ -25,6 +25,16 @@ class NotRegisteredKlass(SomeKlass):
     ...
 
 
+@register_as('functions')
+def dummy_func():
+    return 'Something'
+
+
+@register_as('functions')
+def do_sum(*args):
+    return sum(args)
+
+
 class TestRegister:
     def test_construction_without_package(self):
         new_register = Register(DummyKlass)
@@ -109,6 +119,13 @@ class TestRegister:
 
         assert "MoreSimpleKlass" not in register.simple.keys()
         assert "SimpleKlass" in register.simple.keys()
+
+    def test_registering_a_function(self):
+        register = Register()
+        assert "dummy_func" in register.functions.keys()
+        assert "do_sum" in register.functions.keys()
+        assert register.functions["dummy_func"]() == "Something"
+        assert register.functions["do_sum"](1, 2, 3) == 6
 
 
 def test_clarify_register_sections():


### PR DESCRIPTION
…n capability

- Added documentation in README.md to illustrate how functions can be registered and utilized, enhancing the library's flexibility.
- Implemented support for registering functions in `objects_register.py` by extending the `register_as` decorator with a new dispatch for `Callable`, allowing functions to be registered similarly to classes.
- Added tests in `tests/test_objects_register.py` to ensure that functions are correctly registered and can be retrieved and executed through the register, ensuring the feature's reliability.